### PR TITLE
fix packet len for big events

### DIFF
--- a/statshouse.go
+++ b/statshouse.go
@@ -475,6 +475,8 @@ func (c *Client) writeHeader(k *metricKeyTransport, skey string, counter float64
 		if left >= 0 {
 			c.batchCount++
 			return left
+		} else {
+			wasLen = batchHeaderLen
 		}
 	}
 	c.packetBuf = c.packetBuf[:wasLen]


### PR DESCRIPTION
Из-за того что 
https://github.com/VKCOM/statshouse-go/blob/master/statshouse.go#L480
Выставляется длина пакета wasLen. 
При попытке записать большой ряд, длина пакета выставляется в значение которое уже было отправлено.
Пример для воспроизведения
```
statshouse.Configure(func(format string, args ...interface{}) {
		fmt.Printf(format, args)
	}, statshouse.DefaultStatsHouseAddr, "dev")
	statshouse.Metric("test", statshouse.Tags{1: "a"}).Count(1)
	statshouse.Metric("test", statshouse.Tags{1: "b"}).Count(1)
	statshouse.Metric("test", statshouse.Tags{1: strings.Repeat("a", 5000)}).Count(1)
	time.Sleep(1 * time.Second)
	for {
		statshouse.Metric("test", statshouse.Tags{1: "b"}).Count(1)
		statshouse.Metric("test", statshouse.Tags{1: strings.Repeat("a", 5000)}).Count(1)
		time.Sleep(1 * time.Second)
	}
```