### PR TITLE
fix: mesage too long on MacOS

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - run: go run github.com/vkcom/statshouse/cmd/statshouse-client-test@master --network=tcp
+      - run: go run github.com/VKCOM/statshouse/cmd/statshouse-client-test@master --network=tcp

--- a/client_packet.go
+++ b/client_packet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math"
 	"net"
+	"runtime"
 
 	"github.com/VKCOM/statshouse-go/internal/basictl"
 )
@@ -155,6 +156,9 @@ func maxPacketSize(network, addr string) int {
 		addr, err := net.ResolveUDPAddr("udp", addr)
 		switch {
 		case err == nil && addr.IP.IsLoopback():
+			if runtime.GOOS == "darwin" {
+				return 1232 // macOS has stricter UDP limits on loopback interface
+			}
 			return 65507 // https://stackoverflow.com/questions/42609561/udp-maximum-packet-size/42610200
 		default:
 			return 1232 // IPv6 mandated minimum MTU size of 1280 (minus 40 byte IPv6 header and 8 byte UDP header)


### PR DESCRIPTION
MacOS has smaller udp buffer on localhost then Linux